### PR TITLE
-removed "filter_type" from RIMS

### DIFF
--- a/src/app/dashboard/pages/entities/entities.config.ts
+++ b/src/app/dashboard/pages/entities/entities.config.ts
@@ -220,7 +220,8 @@ export const ENTITIES = {
                 },
                 list: {
                     parser: 'count',
-                    filterable: false
+                    filterable: false,
+
                 },
 
             },
@@ -288,7 +289,9 @@ export const ENTITIES = {
                 },
                 list: {
                     parser: 'count',
-                    filter_type: 'range',
+                    filterable: false,
+                    // filter_type: 'range',
+                    
                 },
 
             }


### PR DESCRIPTION
This is what was causing the RIMS page not to load